### PR TITLE
Enable event propogation on info box

### DIFF
--- a/public/js/always.js
+++ b/public/js/always.js
@@ -304,7 +304,7 @@ apos.define('apostrophe-places-map', {
           closeBoxURL: "//www.google.com/intl/en_us/mapfiles/close.gif",
           infoBoxClearance: new google.maps.Size(1, 1),
           pane: "floatPane",
-          enableEventPropagation: false
+          enableEventPropagation: true
         };
 
         item.infoBox = new InfoBox(boxOptions);


### PR DESCRIPTION
False doesn’t allow the attachment of click events to children of info box